### PR TITLE
Explicitly cast `smtp_start_tls` 

### DIFF
--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -23,7 +23,7 @@ html_directory = no
 manpage_directory = /usr/share/man
 sample_directory = /usr/share/doc/postfix-2.10.1/samples
 readme_directory = /usr/share/doc/postfix-2.10.1/README_FILES
-{% if( smtp_start_tls == true )  %}
+{% if( smtp_start_tls | bool == true )  %}
 relayhost = {{ smtp_host }}:{{ smtp_port }}
 smtp_use_tls = yes
 {% else %}

--- a/templates/sasl_passwd.j2
+++ b/templates/sasl_passwd.j2
@@ -1,4 +1,4 @@
-{% if( smtp_start_tls == true )  %}
+{% if( smtp_start_tls | bool == true )  %}
 {{ smtp_host }}:{{ smtp_port }} {{ smtp_authuser }}:{{ smtp_authpassword }}
 {% else %}
 [127.0.0.1]:1025 {{ smtp_authuser }}:{{ smtp_authpassword }}


### PR DESCRIPTION
Explicitly cast `smtp_start_tls` value to Boolean  so that mail config templates work.

The current conditionals appear to be doing a string comparison and don't ever trigger. 